### PR TITLE
feat: enhance fantasy-themed UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,8 +7,14 @@
 }
 
 body {
-  @apply bg-white text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100;
+  @apply font-body;
 }
 
-.prose a { @apply underline underline-offset-2; }
-nav a { @apply hover:underline underline-offset-4; }
+@layer base {
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-heading text-royal-gold;
+  }
+}
+
+.prose a { @apply underline underline-offset-2 text-royal-gold hover:text-yellow-300; }
+nav a { @apply hover:text-royal-gold transition-colors; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { Cinzel, Merriweather } from "next/font/google";
 
 export const metadata: Metadata = {
   title: "The Elnsburg Continuum",
@@ -15,23 +16,26 @@ export const metadata: Metadata = {
   }
 };
 
+const heading = Cinzel({ subsets: ["latin"], variable: "--font-heading", weight: ["400", "700"] });
+const body = Merriweather({ subsets: ["latin"], variable: "--font-body", weight: ["400", "700"] });
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body className="min-h-screen">
-        <header className="border-b border-zinc-200/50 dark:border-zinc-800/50">
+    <html lang="en" className={`${heading.variable} ${body.variable}`}>
+      <body className="min-h-screen bg-gradient-to-br from-night-sky via-indigo-950 to-black text-parchment font-body">
+        <header className="border-b border-royal-gold/20 bg-gradient-to-r from-night-sky to-indigo-950 shadow-md">
           <div className="mx-auto max-w-5xl px-4 py-4 flex items-center justify-between">
-            <Link href="/" className="text-xl font-semibold">Elnsburg Continuum</Link>
-            <nav className="flex gap-6 text-sm">
-              <Link href="/#novels">Novels</Link>
-              <Link href="/wiki">Wiki</Link>
-              <a href="/api/rss">RSS</a>
+            <Link href="/" className="text-2xl font-heading text-royal-gold">Elnsburg Continuum</Link>
+            <nav className="flex gap-6 text-sm text-parchment">
+              <Link href="/#novels" className="hover:text-royal-gold">Novels</Link>
+              <Link href="/wiki" className="hover:text-royal-gold">Wiki</Link>
+              <a href="/api/rss" className="hover:text-royal-gold">RSS</a>
             </nav>
           </div>
         </header>
         <main className="mx-auto max-w-5xl px-4 py-8">{children}</main>
-        <footer className="border-t border-zinc-200/50 dark:border-zinc-800/50 mt-16">
-          <div className="mx-auto max-w-5xl px-4 py-8 text-sm text-zinc-500">
+        <footer className="border-t border-royal-gold/20 mt-16 bg-night-sky/50">
+          <div className="mx-auto max-w-5xl px-4 py-8 text-sm text-center text-parchment">
             © {new Date().getFullYear()} The Elnsburg Continuum
           </div>
         </footer>

--- a/app/novels/[series]/[chapter]/page.tsx
+++ b/app/novels/[series]/[chapter]/page.tsx
@@ -25,7 +25,7 @@ export default function ChapterPage({ params }: { params: { series: string; chap
   const next = idx < seriesChapters.length - 1 ? seriesChapters[idx + 1] : null;
 
   return (
-    <article className="prose dark:prose-invert mx-auto">
+    <article className="prose prose-invert prose-headings:font-heading prose-headings:text-royal-gold mx-auto">
       <h1>{doc.title}</h1>
       <MDXContent code={doc.body.code} />
       <hr />
@@ -33,7 +33,7 @@ export default function ChapterPage({ params }: { params: { series: string; chap
         <div>{prev && <Link href={prev.slug}>← {prev.title}</Link>}</div>
         <div>{next && <Link href={next.slug}>{next.title} →</Link>}</div>
       </nav>
-      <p className="text-xs text-zinc-500 mt-8">Series: {doc.series} • Chapter {doc.chapter}</p>
+      <p className="text-xs text-parchment/70 mt-8">Series: {doc.series} • Chapter {doc.chapter}</p>
     </article>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,37 +9,37 @@ export default function HomePage() {
   return (
     <div className="space-y-12">
       <section className="space-y-4">
-        <h1 className="text-3xl font-bold">Power, Curses, & Broken Promises</h1>
-        <p className="text-zinc-600 dark:text-zinc-400 max-w-2xl">
+        <h1 className="text-4xl font-heading text-royal-gold">Power, Curses, & Broken Promises</h1>
+        <p className="text-parchment/80 max-w-2xl">
           The flagship webnovel in the Elnsburg Continuum — a city of saints, curses, and political factions.
         </p>
         <div>
-          <Link href={`/novels/${mainSeries}/001`} className="inline-block rounded px-4 py-2 border">
+          <Link href={`/novels/${mainSeries}/001`} className="inline-block rounded px-4 py-2 bg-royal-gold text-night-sky font-bold hover:bg-yellow-400">
             Start at Chapter 1
           </Link>
         </div>
       </section>
 
       <section id="novels" className="space-y-4">
-        <h2 className="text-2xl font-semibold">Latest Chapters</h2>
+        <h2 className="text-3xl font-heading text-royal-gold">Latest Chapters</h2>
         <ul className="space-y-3">
           {chapters.map(c => (
-            <li key={c._id} className="border p-4 rounded">
-              <Link href={c.slug} className="text-lg font-medium">{c.title}</Link>
-              <div className="text-xs mt-1 text-zinc-500">Series: {c.series} • Chapter {c.chapter}</div>
-              {c.synopsis && <p className="mt-2 text-sm text-zinc-700 dark:text-zinc-300">{c.synopsis}</p>}
+            <li key={c._id} className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded">
+              <Link href={c.slug} className="text-lg font-heading text-royal-gold">{c.title}</Link>
+              <div className="text-xs mt-1 text-parchment/70">Series: {c.series} • Chapter {c.chapter}</div>
+              {c.synopsis && <p className="mt-2 text-sm text-parchment/80">{c.synopsis}</p>}
             </li>
           ))}
         </ul>
       </section>
 
       <section className="space-y-4">
-        <h2 className="text-2xl font-semibold">From the Wiki</h2>
+        <h2 className="text-3xl font-heading text-royal-gold">From the Wiki</h2>
         <ul className="grid sm:grid-cols-2 gap-4">
           {wiki.map(w => (
-            <li key={w._id} className="border p-4 rounded">
-              <Link href={w.slug} className="font-medium">{w.title}</Link>
-              {w.summary && <p className="text-sm mt-2 text-zinc-700 dark:text-zinc-300">{w.summary}</p>}
+            <li key={w._id} className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded">
+              <Link href={w.slug} className="font-heading text-royal-gold">{w.title}</Link>
+              {w.summary && <p className="text-sm mt-2 text-parchment/80">{w.summary}</p>}
             </li>
           ))}
         </ul>

--- a/app/wiki/[slug]/page.tsx
+++ b/app/wiki/[slug]/page.tsx
@@ -10,7 +10,7 @@ export default function WikiPage({ params }: { params: { slug: string } }) {
   const doc = allWikis.find(w => w.slug.endsWith(params.slug));
   if (!doc) return notFound();
   return (
-    <article className="prose dark:prose-invert mx-auto">
+    <article className="prose prose-invert prose-headings:font-heading prose-headings:text-royal-gold mx-auto">
       <h1>{doc.title}</h1>
       <MDXContent code={doc.body.code} />
     </article>

--- a/app/wiki/page.tsx
+++ b/app/wiki/page.tsx
@@ -5,12 +5,12 @@ export default function WikiIndex() {
   const docs = [...allWikis].sort((a,b)=> a.title.localeCompare(b.title));
   return (
     <div className="space-y-6">
-      <h1 className="text-3xl font-bold">Elnsburg Wiki</h1>
+      <h1 className="text-4xl font-heading text-royal-gold">Elnsburg Wiki</h1>
       <ul className="grid sm:grid-cols-2 gap-4">
         {docs.map(d => (
-          <li key={d._id} className="border p-4 rounded">
-            <Link href={d.slug} className="font-medium">{d.title}</Link>
-            {d.tags?.length ? <div className="text-xs mt-2">{d.tags.join(" • ")}</div> : null}
+          <li key={d._id} className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded">
+            <Link href={d.slug} className="font-heading text-royal-gold">{d.title}</Link>
+            {d.tags?.length ? <div className="text-xs mt-2 text-parchment/70">{d.tags.join(" • ")}</div> : null}
           </li>
         ))}
       </ul>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,15 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        parchment: "#f5f1e8",
+        "night-sky": "#0f0b2d",
+        "royal-gold": "#eab308"
+      },
+      fontFamily: {
+        heading: ["var(--font-heading)", "serif"],
+        body: ["var(--font-body)", "serif"]
+      },
       typography: {
         DEFAULT: {
           css: {


### PR DESCRIPTION
## Summary
- Add fantasy-inspired fonts and color palette
- Style layout, home, and wiki pages with dramatic gradients and gold accents
- Apply consistent heading styles in markdown content

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6896b1e5a374832a8d2c08a4870c9651