### PR TITLE
feat: add wiki admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ npm run dev
 Content lives in `content/novels/*/chapters/*.mdx` and `content/wiki/*.mdx`.
 Edit or add files, and the site updates.
 
+An admin interface is available for quickly creating content without touching the files directly:
+
+- `(/admin)` for novel chapters
+- `(/admin/wiki)` for wiki entries
+
 ## Deploy
 - Vercel recommended: import repo, set `NEXT_PUBLIC_SITE_URL` env (e.g., https://your-domain)
 - Static hosting also works with `next export` (limited features).

--- a/app/admin/wiki/page.tsx
+++ b/app/admin/wiki/page.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useState } from 'react';
+
+function slugify(input: string) {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export default function WikiAdminPage() {
+  const [password, setPassword] = useState('');
+  const [title, setTitle] = useState('');
+  const [slug, setSlug] = useState('');
+  const [summary, setSummary] = useState('');
+  const [tags, setTags] = useState('');
+  const [content, setContent] = useState<string>('Write your wiki entry here.');
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<{ ok?: boolean; fileUrl?: string; previewSlug?: string; error?: string } | null>(null);
+
+  const previewPath = `/wiki/${slug}`;
+
+  async function publish() {
+    setBusy(true);
+    setResult(null);
+    try {
+      const res = await fetch('/api/save-wiki', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-admin-secret': password,
+        },
+        body: JSON.stringify({ title, slug, summary, tags, content }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setResult({ error: json?.error || 'Failed to publish' });
+      } else {
+        setResult({ ok: true, fileUrl: json.fileUrl, previewSlug: json.previewSlug });
+      }
+    } catch (e: any) {
+      setResult({ error: e?.message || 'Network error' });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <h1 className="text-2xl font-semibold">Wiki Admin</h1>
+      <div className="grid gap-4">
+        <label className="grid gap-1">
+          <span className="text-sm">Admin Password</span>
+          <input
+            type="password"
+            className="border rounded px-3 py-2"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="••••••••••"
+          />
+        </label>
+
+        <label className="grid gap-1">
+          <span className="text-sm">Title</span>
+          <input
+            className="border rounded px-3 py-2"
+            value={title}
+            onChange={(e) => {
+              const t = e.target.value;
+              setTitle(t);
+              setSlug(slugify(t));
+            }}
+          />
+        </label>
+
+        <label className="grid gap-1">
+          <span className="text-sm">Slug</span>
+          <input
+            className="border rounded px-3 py-2 font-mono"
+            value={slug}
+            onChange={(e) => setSlug(slugify(e.target.value))}
+            placeholder="elnsburg-overview"
+          />
+        </label>
+
+        <label className="grid gap-1">
+          <span className="text-sm">Summary (optional)</span>
+          <input
+            className="border rounded px-3 py-2"
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+          />
+        </label>
+
+        <label className="grid gap-1">
+          <span className="text-sm">Tags (comma-separated)</span>
+          <input
+            className="border rounded px-3 py-2"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            placeholder="overview, factions"
+          />
+        </label>
+
+        <label className="grid gap-1">
+          <span className="text-sm">Content (MDX)</span>
+          <textarea
+            className="border rounded px-3 py-2 min-h-[300px] font-mono"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+          />
+        </label>
+
+        <div className="flex items-center gap-3">
+          <button
+            className="rounded px-4 py-2 border disabled:opacity-50"
+            onClick={publish}
+            disabled={busy || !password || !slug || !title}
+          >
+            {busy ? 'Publishing…' : 'Publish'}
+          </button>
+          <span className="text-sm text-zinc-500">Preview URL (after deploy): <code>{previewPath}</code></span>
+        </div>
+
+        {result?.ok && (
+          <div className="rounded border p-3 text-sm">
+            ✅ Published! {result.fileUrl ? (
+              <a className="underline" href={result.fileUrl} target="_blank">View file on GitHub</a>
+            ) : null}
+            {result.previewSlug ? <> • Preview on site: <code>{result.previewSlug}</code> (after deploy)</> : null}
+          </div>
+        )}
+        {result?.error && (
+          <div className="rounded border p-3 text-sm text-red-600">
+            ⚠️ {result.error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/api/save-wiki/route.ts
+++ b/app/api/save-wiki/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+
+interface Payload {
+  title: string;
+  slug: string;
+  summary?: string;
+  tags?: string; // comma-separated
+  content: string; // MDX body (no frontmatter)
+}
+
+function slugify(input: string) {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export async function POST(req: NextRequest) {
+  if (req.headers.get("x-admin-secret") !== process.env.ADMIN_PASSWORD) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const body = (await req.json()) as Payload;
+  const { title, slug, summary = "", tags = "", content } = body;
+
+  if (!title || !slug || !content) {
+    return NextResponse.json(
+      { error: "Missing required fields (title, slug, content)" },
+      { status: 400 }
+    );
+  }
+
+  const finalSlug = slugify(slug);
+  const tagList = tags
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const frontmatter =
+    `---\n` +
+    `title: ${JSON.stringify(title)}\n` +
+    (summary ? `summary: ${JSON.stringify(summary)}\n` : "") +
+    (tagList.length
+      ? `tags: [${tagList.map((t) => JSON.stringify(t)).join(", ")}]\n`
+      : "") +
+    `---\n`;
+
+  const mdx = `${frontmatter}${content.trim()}\n`;
+
+  const repo = process.env.GITHUB_REPO!;
+  const [owner, repoName] = repo.split("/");
+  const branch = process.env.GITHUB_DEFAULT_BRANCH || "main";
+  const path = `content/wiki/${finalSlug}.mdx`;
+  const apiBase = `https://api.github.com`;
+  const contentsUrl = `${apiBase}/repos/${owner}/${repoName}/contents/${encodeURIComponent(
+    path
+  )}`;
+  const headers = {
+    Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+    "Content-Type": "application/json",
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  let sha: string | undefined;
+  const head = await fetch(`${contentsUrl}?ref=${branch}`, { headers });
+  if (head.ok) {
+    const j = (await head.json()) as { sha?: string };
+    sha = j.sha;
+  }
+
+  const commitMessage = `${sha ? "chore" : "feat"}(wiki): ${title}`;
+  const put = await fetch(contentsUrl, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify({
+      message: commitMessage,
+      content: Buffer.from(mdx, "utf8").toString("base64"),
+      branch,
+      ...(sha ? { sha } : {}),
+    }),
+  });
+
+  if (!put.ok) {
+    return NextResponse.json(
+      { error: "GitHub PUT failed", details: await put.text() },
+      { status: 500 }
+    );
+  }
+
+  const json = await put.json();
+  const fileUrl = json?.content?.html_url ?? null;
+  const previewSlug = `/wiki/${finalSlug}`;
+
+  return NextResponse.json({ ok: true, fileUrl, previewSlug, path, branch });
+}


### PR DESCRIPTION
## Summary
- add API route to save wiki entries to the repo
- add admin UI for creating wiki pages
- document admin URLs in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: asks to configure ESLint)*
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6896befe44a0832aa1481be1ea5731c6