### PR TITLE
Add novel series and chapter listing pages

### DIFF
--- a/app/novels/[series]/page.tsx
+++ b/app/novels/[series]/page.tsx
@@ -1,0 +1,43 @@
+import { allChapters } from "contentlayer/generated";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+
+export function generateStaticParams() {
+  return Array.from(new Set(allChapters.map((c) => c.seriesSlug))).map(
+    (series) => ({ series })
+  );
+}
+
+export default function SeriesPage({ params }: { params: { series: string } }) {
+  const chapters = allChapters
+    .filter((c) => c.seriesSlug === params.series)
+    .sort((a, b) => a.chapter - b.chapter);
+
+  if (chapters.length === 0) return notFound();
+
+  const seriesName = chapters[0].series;
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-4xl font-heading text-royal-gold">{seriesName}</h1>
+      <ul className="space-y-3">
+        {chapters.map((c) => (
+          <li
+            key={c._id}
+            className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded"
+          >
+            <Link href={c.slug} className="font-heading text-royal-gold">
+              {c.title}
+            </Link>
+            <div className="text-xs mt-1 text-parchment/70">
+              Chapter {c.chapter}
+            </div>
+            {c.synopsis && (
+              <p className="mt-2 text-sm text-parchment/80">{c.synopsis}</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/novels/page.tsx
+++ b/app/novels/page.tsx
@@ -1,0 +1,38 @@
+import { allChapters } from "contentlayer/generated";
+import Link from "next/link";
+
+export default function NovelsIndex() {
+  const seriesMap = new Map<string, typeof allChapters[number]>();
+  for (const chapter of allChapters) {
+    if (!seriesMap.has(chapter.seriesSlug)) {
+      seriesMap.set(chapter.seriesSlug, chapter);
+    }
+  }
+  const series = Array.from(seriesMap.values()).sort((a, b) =>
+    a.series.localeCompare(b.series)
+  );
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-4xl font-heading text-royal-gold">Web Novels</h1>
+      <ul className="grid sm:grid-cols-2 gap-4">
+        {series.map((s) => (
+          <li
+            key={s.seriesSlug}
+            className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded"
+          >
+            <Link
+              href={`/novels/${s.seriesSlug}`}
+              className="font-heading text-royal-gold"
+            >
+              {s.series}
+            </Link>
+            <div className="text-xs mt-2 text-parchment/70">
+              {allChapters.filter((c) => c.seriesSlug === s.seriesSlug).length} chapters
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/novels` index page that lists available series with chapter counts
- add series page that shows all chapters for a given series

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration and exits)*

------
https://chatgpt.com/codex/tasks/task_e_689a89682cb8832a8f3c2fa3600953f8