### PR TITLE
Add novel series pages and wiki search

### DIFF
--- a/app/novels/[series]/page.tsx
+++ b/app/novels/[series]/page.tsx
@@ -1,0 +1,28 @@
+import { allChapters } from 'contentlayer/generated';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+export function generateStaticParams() {
+  const slugs = Array.from(new Set(allChapters.map(c => c.seriesSlug)));
+  return slugs.map(series => ({ series }));
+}
+
+export default function SeriesPage({ params }: { params: { series: string } }) {
+  const chapters = allChapters
+    .filter(c => c.seriesSlug === params.series)
+    .sort((a,b)=> a.chapter - b.chapter);
+  if (!chapters.length) return notFound();
+  return (
+    <div className="space-y-6">
+      <h1 className="text-4xl font-heading text-royal-gold">{chapters[0].series}</h1>
+      <ul className="space-y-3">
+        {chapters.map(c => (
+          <li key={c._id} className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded">
+            <Link href={c.slug} className="font-heading text-royal-gold">Chapter {c.chapter}: {c.title}</Link>
+            {c.synopsis && <p className="text-sm mt-2 text-parchment/80">{c.synopsis}</p>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/novels/page.tsx
+++ b/app/novels/page.tsx
@@ -1,0 +1,22 @@
+import { allChapters } from 'contentlayer/generated';
+import Link from 'next/link';
+
+export default function NovelsIndex() {
+  const seriesMap = new Map<string, string>();
+  for (const c of allChapters) {
+    if (!seriesMap.has(c.seriesSlug)) seriesMap.set(c.seriesSlug, c.series);
+  }
+  const series = Array.from(seriesMap.entries()).sort((a,b)=> a[1].localeCompare(b[1]));
+  return (
+    <div className="space-y-6">
+      <h1 className="text-4xl font-heading text-royal-gold">Novels</h1>
+      <ul className="space-y-3">
+        {series.map(([slug, name]) => (
+          <li key={slug} className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded">
+            <Link href={`/novels/${slug}`} className="font-heading text-royal-gold">{name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,45 +1,80 @@
-import { allChapters, allWikis } from 'contentlayer/generated';
+import { allChapters, allWikis } from "contentlayer/generated";
 import Link from "next/link";
 
 export default function HomePage() {
-  const chapters = [...allChapters].sort((a,b)=> b.chapter - a.chapter).slice(0,5);
-  const wiki = [...allWikis].slice(0,5);
-  const mainSeries = "power-curses-broken-promises";
+  const mainSeriesSlug = "power-curses-and-broken-promises";
+  const latest = [...allChapters]
+    .filter((c) => c.seriesSlug === mainSeriesSlug)
+    .sort((a, b) => b.chapter - a.chapter)[0];
+  const wiki = [...allWikis].slice(0, 5);
 
   return (
     <div className="space-y-12">
       <section className="space-y-4">
-        <h1 className="text-4xl font-heading text-royal-gold">Power, Curses, & Broken Promises</h1>
+        <h1 className="text-4xl font-heading text-royal-gold">
+          Power, Curses, & Broken Promises
+        </h1>
         <p className="text-parchment/80 max-w-2xl">
-          The flagship webnovel in the Elnsburg Continuum — a city of saints, curses, and political factions.
+          The flagship webnovel in the Elnsburg Continuum — a city of saints,
+          curses, and political factions.
         </p>
-        <div>
-          <Link href={`/novels/power-curses-and-broken-promises/001`} className="inline-block rounded px-4 py-2 bg-royal-gold text-night-sky font-bold hover:bg-yellow-400">
+        <div className="flex gap-2">
+          <Link
+            href={`/novels/power-curses-and-broken-promises/001`}
+            className="inline-block rounded px-4 py-2 bg-royal-gold text-night-sky font-bold hover:bg-yellow-400"
+          >
             Start at Chapter 1
           </Link>
+          {latest && (
+            <Link
+              href={latest.slug}
+              className="inline-block rounded px-4 py-2 border border-royal-gold text-royal-gold font-bold hover:bg-royal-gold/10"
+            >
+              Latest Chapter
+            </Link>
+          )}
         </div>
       </section>
 
-      <section id="novels" className="space-y-4">
-        <h2 className="text-3xl font-heading text-royal-gold">Latest Chapters</h2>
-        <ul className="space-y-3">
-          {chapters.map(c => (
-            <li key={c._id} className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded">
-              <Link href={c.slug} className="text-lg font-heading text-royal-gold">{c.title}</Link>
-              <div className="text-xs mt-1 text-parchment/70">Series: {c.series} • Chapter {c.chapter}</div>
-              {c.synopsis && <p className="mt-2 text-sm text-parchment/80">{c.synopsis}</p>}
+      {latest && (
+        <section id="novels" className="space-y-4">
+          <h2 className="text-3xl font-heading text-royal-gold">Latest Chapter</h2>
+          <ul className="space-y-3">
+            <li
+              key={latest._id}
+              className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded"
+            >
+              <Link
+                href={latest.slug}
+                className="text-lg font-heading text-royal-gold"
+              >
+                {latest.title}
+              </Link>
+              <div className="text-xs mt-1 text-parchment/70">
+                Series: {latest.series} • Chapter {latest.chapter}
+              </div>
+              {latest.synopsis && (
+                <p className="mt-2 text-sm text-parchment/80">{latest.synopsis}</p>
+              )}
             </li>
-          ))}
-        </ul>
-      </section>
+          </ul>
+        </section>
+      )}
 
       <section className="space-y-4">
         <h2 className="text-3xl font-heading text-royal-gold">From the Wiki</h2>
         <ul className="grid sm:grid-cols-2 gap-4">
-          {wiki.map(w => (
-            <li key={w._id} className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded">
-              <Link href={w.slug} className="font-heading text-royal-gold">{w.title}</Link>
-              {w.summary && <p className="text-sm mt-2 text-parchment/80">{w.summary}</p>}
+          {wiki.map((w) => (
+            <li
+              key={w._id}
+              className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded"
+            >
+              <Link href={w.slug} className="font-heading text-royal-gold">
+                {w.title}
+              </Link>
+              {w.summary && (
+                <p className="text-sm mt-2 text-parchment/80">{w.summary}</p>
+              )}
             </li>
           ))}
         </ul>

--- a/app/wiki/page.tsx
+++ b/app/wiki/page.tsx
@@ -1,16 +1,44 @@
+"use client";
+
 import { allWikis } from "contentlayer/generated";
 import Link from "next/link";
+import { useState } from "react";
 
 export default function WikiIndex() {
-  const docs = [...allWikis].sort((a,b)=> a.title.localeCompare(b.title));
+  const docs = [...allWikis].sort((a, b) => a.title.localeCompare(b.title));
+  const [query, setQuery] = useState("");
+  const filtered = docs.filter((d) => {
+    const q = query.toLowerCase();
+    return (
+      d.title.toLowerCase().includes(q) ||
+      d.tags?.some((t) => t.toLowerCase().includes(q))
+    );
+  });
   return (
     <div className="space-y-6">
       <h1 className="text-4xl font-heading text-royal-gold">Elnsburg Wiki</h1>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search wiki..."
+        aria-label="Search wiki"
+        className="w-full rounded border border-royal-gold/30 bg-night-sky/40 p-2"
+      />
       <ul className="grid sm:grid-cols-2 gap-4">
-        {docs.map(d => (
-          <li key={d._id} className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded">
-            <Link href={d.slug} className="font-heading text-royal-gold">{d.title}</Link>
-            {d.tags?.length ? <div className="text-xs mt-2 text-parchment/70">{d.tags.join(" • ")}</div> : null}
+        {filtered.map((d) => (
+          <li
+            key={d._id}
+            className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded"
+          >
+            <Link href={d.slug} className="font-heading text-royal-gold">
+              {d.title}
+            </Link>
+            {d.tags?.length ? (
+              <div className="text-xs mt-2 text-parchment/70">
+                {d.tags.join(" • ")}
+              </div>
+            ) : null}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- Add index pages for novels and individual series to list chapters
- Show latest chapter of main series on home page
- Enable client-side search on wiki page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive prompt to configure ESLint)*
- `npm run build` *(fails: Failed to fetch fonts from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689a8bcfb674832a95a553074a04343c