### PR TITLE
Add NextAuth auth and progress tracking

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,17 @@
+import NextAuth from "next-auth";
+import GitHubProvider from "next-auth/providers/github";
+import { PrismaAdapter } from "@next-auth/prisma-adapter";
+import { prisma } from "@/lib/prisma";
+
+export const authOptions = {
+  adapter: PrismaAdapter(prisma),
+  providers: [
+    GitHubProvider({
+      clientId: process.env.GITHUB_ID || "",
+      clientSecret: process.env.GITHUB_SECRET || ""
+    })
+  ]
+};
+
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };

--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]/route";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ progress: [] });
+  }
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    include: { progress: true }
+  });
+  return NextResponse.json({ progress: user?.progress ?? [] });
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const { series, chapter } = await req.json();
+  const user = await prisma.user.upsert({
+    where: { email: session.user.email },
+    update: {},
+    create: { email: session.user.email, name: session.user.name ?? undefined }
+  });
+  await prisma.progress.upsert({
+    where: { userId_series_chapter: { userId: user.id, series, chapter } },
+    update: {},
+    create: { userId: user.id, series, chapter }
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,9 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getServerSession } from "next-auth";
+import { authOptions } from "./api/auth/[...nextauth]/route";
+import { ProgressProvider } from "@/components/progress-provider";
 import { Cinzel, Merriweather } from "next/font/google";
 
 export const metadata: Metadata = {
@@ -19,21 +22,29 @@ export const metadata: Metadata = {
 const heading = Cinzel({ subsets: ["latin"], variable: "--font-heading", weight: ["400", "700"] });
 const body = Merriweather({ subsets: ["latin"], variable: "--font-body", weight: ["400", "700"] });
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const session = await getServerSession(authOptions);
   return (
     <html lang="en" className={`${heading.variable} ${body.variable}`}>
       <body className="min-h-screen bg-gradient-to-br from-night-sky via-indigo-950 to-black text-parchment font-body">
         <header className="border-b border-royal-gold/20 bg-gradient-to-r from-night-sky to-indigo-950 shadow-md">
           <div className="mx-auto max-w-5xl px-4 py-4 flex items-center justify-between">
             <Link href="/" className="text-2xl font-heading text-royal-gold">Elnsburg Continuum</Link>
-            <nav className="flex gap-6 text-sm text-parchment">
+            <nav className="flex gap-6 text-sm text-parchment items-center">
               <Link href="/novels" className="hover:text-royal-gold">Novels</Link>
               <Link href="/wiki" className="hover:text-royal-gold">Wiki</Link>
               <a href="/api/rss" className="hover:text-royal-gold">RSS</a>
+              {session ? (
+                <Link href="/api/auth/signout" className="hover:text-royal-gold">Logout</Link>
+              ) : (
+                <Link href="/api/auth/signin" className="hover:text-royal-gold">Login</Link>
+              )}
             </nav>
           </div>
         </header>
-        <main className="mx-auto max-w-5xl px-4 py-8">{children}</main>
+        <ProgressProvider>
+          <main className="mx-auto max-w-5xl px-4 py-8">{children}</main>
+        </ProgressProvider>
         <footer className="border-t border-royal-gold/20 mt-16 bg-night-sky/50">
           <div className="mx-auto max-w-5xl px-4 py-8 text-sm text-center text-parchment">
             © {new Date().getFullYear()} The Elnsburg Continuum

--- a/app/novels/[series]/[chapter]/page.tsx
+++ b/app/novels/[series]/[chapter]/page.tsx
@@ -2,12 +2,28 @@ import { allChapters } from "contentlayer/generated";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { MDXContent } from "@/components/mdx-content";
+import { useEffect } from "react";
+import { useProgress } from "@/components/progress-provider";
 
 export function generateStaticParams() {
   return allChapters.map((c) => ({
     series: c.seriesSlug,
     chapter: String(c.chapter).padStart(3, "0"),
   }));
+}
+
+function ChapterProgress({ series, chapter }: { series: string; chapter: number }) {
+  "use client";
+  const { progress, add } = useProgress();
+  const read = progress.some((p) => p.series === series && p.chapter === chapter);
+  useEffect(() => {
+    fetch("/api/progress", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ series, chapter })
+    }).then(() => add({ series, chapter }));
+  }, [series, chapter, add]);
+  return read ? <span className="ml-2 text-xs text-green-400">(Read)</span> : null;
 }
 
 export default function ChapterPage({ params }: { params: { series: string; chapter: string } }) {
@@ -26,7 +42,10 @@ export default function ChapterPage({ params }: { params: { series: string; chap
 
   return (
     <article className="prose prose-invert prose-headings:font-heading prose-headings:text-royal-gold mx-auto">
-      <h1>{doc.title}</h1>
+      <h1>
+        {doc.title}
+        <ChapterProgress series={doc.seriesSlug} chapter={doc.chapter} />
+      </h1>
       <MDXContent code={doc.body.code} />
       <hr />
       <nav className="flex justify-between text-sm">

--- a/components/progress-provider.tsx
+++ b/components/progress-provider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Progress = { id?: string; series: string; chapter: number };
+
+type ProgressContextType = { progress: Progress[]; add: (p: Progress) => void };
+
+const ProgressContext = createContext<ProgressContextType>({ progress: [], add: () => {} });
+
+export function ProgressProvider({ children }: { children: React.ReactNode }) {
+  const [progress, setProgress] = useState<Progress[]>([]);
+
+  useEffect(() => {
+    fetch("/api/progress")
+      .then((res) => res.json())
+      .then((data) => setProgress(data.progress || []))
+      .catch(() => {});
+  }, []);
+
+  const add = (p: Progress) => setProgress((prev) => [...prev, p]);
+
+  return <ProgressContext.Provider value={{ progress, add }}>{children}</ProgressContext.Provider>;
+}
+
+export function useProgress() {
+  return useContext(ProgressContext);
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["query"] : []
+  });
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "remark-gfm": "4.0.0",
     "rehype-slug": "6.0.0",
     "rehype-autolink-headings": "7.1.0",
-    "clsx": "2.1.1"
+    "clsx": "2.1.1",
+    "next-auth": "^4.24.7",
+    "@next-auth/prisma-adapter": "^1.0.7",
+    "@prisma/client": "^5.18.0"
   },
   "devDependencies": {
     "@contentlayer2/cli": "^0.4.3",
@@ -29,7 +32,8 @@
     "autoprefixer": "10.4.19",
     "postcss": "8.4.38",
     "tailwindcss": "3.4.7",
-    "typescript": "5.4.5"
+    "typescript": "5.4.5",
+    "prisma": "^5.18.0"
   },
   "engines": {
     "node": "20.x"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,62 @@
+// Prisma schema for NextAuth and progress
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model User {
+  id       String    @id @default(cuid())
+  name     String?
+  email    String?   @unique
+  image    String?
+  accounts Account[]
+  sessions Session[]
+  progress Progress[]
+}
+
+model Account {
+  id                 String  @id @default(cuid())
+  userId             String
+  type               String
+  provider           String
+  providerAccountId  String
+  refresh_token      String? @db.Text
+  access_token       String? @db.Text
+  expires_at         Int?
+  token_type         String?
+  scope              String?
+  id_token           String? @db.Text
+  session_state      String?
+  user               User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}
+
+model Progress {
+  id      String  @id @default(cuid())
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId  String
+  series  String
+  chapter Int
+  @@unique([userId, series, chapter])
+}


### PR DESCRIPTION
## Summary
- integrate NextAuth with GitHub provider and Prisma adapter
- add Prisma schema and client for user and chapter progress persistence
- expose progress API and load progress in layout with login/logout controls
- mark chapters as read on view using progress API

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (incomplete: requires interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_689b84494654832aadf07edc9083d01d