### PR TITLE
feat: extract chapter progress component

### DIFF
--- a/app/novels/[series]/[chapter]/page.tsx
+++ b/app/novels/[series]/[chapter]/page.tsx
@@ -2,6 +2,7 @@ import { allChapters } from "contentlayer/generated";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { MDXContent } from "@/components/mdx-content";
+import { ChapterProgress } from "@/components/chapter-progress";
 
 export function generateStaticParams() {
   return allChapters.map((c) => ({
@@ -25,15 +26,18 @@ export default function ChapterPage({ params }: { params: { series: string; chap
   const next = idx < seriesChapters.length - 1 ? seriesChapters[idx + 1] : null;
 
   return (
-    <article className="prose prose-invert prose-headings:font-heading prose-headings:text-royal-gold mx-auto">
-      <h1>{doc.title}</h1>
-      <MDXContent code={doc.body.code} />
-      <hr />
-      <nav className="flex justify-between text-sm">
-        <div>{prev && <Link href={prev.slug}>← {prev.title}</Link>}</div>
-        <div>{next && <Link href={next.slug}>{next.title} →</Link>}</div>
-      </nav>
-      <p className="text-xs text-parchment/70 mt-8">Series: {doc.series} • Chapter {doc.chapter}</p>
-    </article>
+    <>
+      <ChapterProgress />
+      <article className="prose prose-invert prose-headings:font-heading prose-headings:text-royal-gold mx-auto">
+        <h1>{doc.title}</h1>
+        <MDXContent code={doc.body.code} />
+        <hr />
+        <nav className="flex justify-between text-sm">
+          <div>{prev && <Link href={prev.slug}>← {prev.title}</Link>}</div>
+          <div>{next && <Link href={next.slug}>{next.title} →</Link>}</div>
+        </nav>
+        <p className="text-xs text-parchment/70 mt-8">Series: {doc.series} • Chapter {doc.chapter}</p>
+      </article>
+    </>
   );
 }

--- a/components/chapter-progress.tsx
+++ b/components/chapter-progress.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from "react";
+
+function useProgress() {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const update = () => {
+      const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+      const total = scrollHeight - clientHeight;
+      const current = scrollTop;
+      setProgress(total > 0 ? current / total : 0);
+    };
+
+    update();
+    window.addEventListener("scroll", update);
+    return () => window.removeEventListener("scroll", update);
+  }, []);
+
+  return progress;
+}
+
+export function ChapterProgress() {
+  const progress = useProgress();
+
+  useEffect(() => {
+    // Reserved for side effects when progress updates (e.g., analytics)
+  }, [progress]);
+
+  return (
+    <div className="fixed left-0 right-0 top-0 h-1 bg-royal-gold/20">
+      <div
+        className="h-full bg-royal-gold transition-all duration-150"
+        style={{ width: `${progress * 100}%` }}
+      />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- move ChapterProgress logic into a dedicated client component
- render ChapterProgress in chapter page via import

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_689ba4fd8784832aac62c3daada44666