### PR TITLE
Add remark plugin for wiki-style links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ An admin interface is available for quickly creating content without touching th
 - `(/admin)` for novel chapters
 - `(/admin/wiki)` for wiki entries
 
+## Authoring
+
+Use double brackets to link to wiki pages. Writing `[[elnsburg-overview]]` in your
+chapter or wiki entry will automatically link to `/wiki/elnsburg-overview`.
+
 ## Deploy
 - Vercel recommended: import repo, set `NEXT_PUBLIC_SITE_URL` env (e.g., https://your-domain)
 - Static hosting also works with `next export` (limited features).

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -43,7 +43,7 @@ export default function AdminPage() {
 
 <Spoiler>Optional spoiler block</Spoiler>
 
-See <WikiLink slug="elnsburg-overview">Elnsburg overview</WikiLink>.`
+See [[elnsburg-overview]].`
   );
 
   // Wiki fields

--- a/components/mdx-content.tsx
+++ b/components/mdx-content.tsx
@@ -4,15 +4,25 @@ import { useMDXComponent } from 'next-contentlayer2/hooks';
 import Link from 'next/link';
 
 const components = {
-  a: (props: any) => <a {...props} />,
+  a: ({ href, children, ...rest }: any) => {
+    if (href?.startsWith('/')) {
+      return (
+        <Link href={href} {...rest}>
+          {children}
+        </Link>
+      );
+    }
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  },
   Spoiler: ({ children }: { children: React.ReactNode }) => (
     <details>
       <summary>Spoiler</summary>
       <div>{children}</div>
     </details>
-  ),
-  WikiLink: ({ slug, children }: { slug: string; children: React.ReactNode }) => (
-    <Link href={`/wiki/${slug}`}>{children}</Link>
   ),
 } as const;
 

--- a/content/novels/power-curses-and-broken-promises/chapters/001.mdx
+++ b/content/novels/power-curses-and-broken-promises/chapters/001.mdx
@@ -10,6 +10,6 @@ Welcome to **Elnsburg**. Write your chapter here.
 
 <Spoiler>Optional spoiler block</Spoiler>
 
-See <WikiLink slug="elnsburg-overview">Elnsburg overview</WikiLink>.
+See [[elnsburg-overview]].
 
 This is a test of categorization.

--- a/content/novels/test/chapters/001.mdx
+++ b/content/novels/test/chapters/001.mdx
@@ -10,6 +10,6 @@ Welcome to **Elnsburg**. Write your chapter here.
 
 <Spoiler>Optional spoiler block</Spoiler>
 
-See <WikiLink slug="elnsburg-overview">Elnsburg overview</WikiLink>.
+See [[elnsburg-overview]].
 
 This is a test of categorization. Again

--- a/content/novels/test/chapters/002.mdx
+++ b/content/novels/test/chapters/002.mdx
@@ -10,6 +10,6 @@ Welcome to **Elnsburg**. Write your chapter here.
 
 <Spoiler>Optional spoiler block</Spoiler>
 
-See <WikiLink slug="elnsburg-overview">Elnsburg overview</WikiLink>.
+See [[elnsburg-overview]].
 
 This is a test of categorization. Again 2

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -2,6 +2,7 @@ import { defineDocumentType, makeSource } from "@contentlayer2/source-files";
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import remarkGfm from "remark-gfm";
+import remarkWikiLinks from "./lib/remark-wikilinks";
 
 export const Chapter = defineDocumentType(() => ({
   name: "Chapter",
@@ -54,7 +55,7 @@ export default makeSource({
   contentDirPath: "content",
   documentTypes: [Chapter, Wiki],
   mdx: {
-    remarkPlugins: [remarkGfm],
+    remarkPlugins: [remarkGfm, remarkWikiLinks],
     rehypePlugins: [rehypeSlug, [rehypeAutolinkHeadings, { behavior: "wrap" }]]
   }
 });

--- a/lib/remark-wikilinks.ts
+++ b/lib/remark-wikilinks.ts
@@ -1,0 +1,38 @@
+import { visit } from 'unist-util-visit';
+import type { Plugin } from 'unified';
+import type { Root, Text, PhrasingContent, Link } from 'mdast';
+
+// remark plugin to transform [[slug]] into wiki links
+const remarkWikiLinks: Plugin<[], Root> = () => {
+  return (tree) => {
+    visit(tree, 'text', (node: Text, index, parent) => {
+      const value = node.value;
+      const regex = /\[\[([^\]]+)\]\]/g;
+      let match: RegExpExecArray | null;
+      let lastIndex = 0;
+      const newNodes: PhrasingContent[] = [];
+      while ((match = regex.exec(value)) !== null) {
+        const [full, slug] = match;
+        const start = match.index;
+        if (start > lastIndex) {
+          newNodes.push({ type: 'text', value: value.slice(lastIndex, start) });
+        }
+        const linkNode: Link = {
+          type: 'link',
+          url: `/wiki/${slug}`,
+          children: [{ type: 'text', value: slug }],
+        };
+        newNodes.push(linkNode);
+        lastIndex = start + full.length;
+      }
+      if (newNodes.length) {
+        if (lastIndex < value.length) {
+          newNodes.push({ type: 'text', value: value.slice(lastIndex) });
+        }
+        parent!.children.splice(index!, 1, ...newNodes);
+      }
+    });
+  };
+};
+
+export default remarkWikiLinks;


### PR DESCRIPTION
## Summary
- add `remark-wikilinks` plugin to convert `[[slug]]` into wiki links
- wire plugin into contentlayer and update MDX link handling
- document and demonstrate new `[[slug]]` authoring syntax

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689bb1be2248832a8dc77ba45ed0532c