### PR TITLE
feat: add theme provider and reader settings

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,8 @@
 
 :root {
   color-scheme: light dark;
+  --reader-font-size: 16px;
+  --reader-line-height: 1.75;
 }
 
 body {
@@ -18,3 +20,8 @@ body {
 
 .prose a { @apply underline underline-offset-2 text-royal-gold hover:text-yellow-300; }
 nav a { @apply hover:text-royal-gold transition-colors; }
+
+.reader-content {
+  font-size: var(--reader-font-size);
+  line-height: var(--reader-line-height);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Cinzel, Merriweather } from "next/font/google";
+import { ThemeProvider, ThemeToggle } from "@/components/theme-provider";
 
 export const metadata: Metadata = {
   title: "The Elnsburg Continuum",
@@ -22,23 +23,26 @@ const body = Merriweather({ subsets: ["latin"], variable: "--font-body", weight:
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${heading.variable} ${body.variable}`}>
-      <body className="min-h-screen bg-gradient-to-br from-night-sky via-indigo-950 to-black text-parchment font-body">
-        <header className="border-b border-royal-gold/20 bg-gradient-to-r from-night-sky to-indigo-950 shadow-md">
-          <div className="mx-auto max-w-5xl px-4 py-4 flex items-center justify-between">
-            <Link href="/" className="text-2xl font-heading text-royal-gold">Elnsburg Continuum</Link>
-            <nav className="flex gap-6 text-sm text-parchment">
-              <Link href="/novels" className="hover:text-royal-gold">Novels</Link>
-              <Link href="/wiki" className="hover:text-royal-gold">Wiki</Link>
-              <a href="/api/rss" className="hover:text-royal-gold">RSS</a>
-            </nav>
-          </div>
-        </header>
-        <main className="mx-auto max-w-5xl px-4 py-8">{children}</main>
-        <footer className="border-t border-royal-gold/20 mt-16 bg-night-sky/50">
-          <div className="mx-auto max-w-5xl px-4 py-8 text-sm text-center text-parchment">
-            © {new Date().getFullYear()} The Elnsburg Continuum
-          </div>
-        </footer>
+      <body className="min-h-screen font-body bg-white text-night-sky dark:bg-gradient-to-br dark:from-night-sky dark:via-indigo-950 dark:to-black dark:text-parchment">
+        <ThemeProvider>
+          <header className="border-b border-royal-gold/20 bg-gray-100 text-night-sky shadow-md dark:bg-gradient-to-r dark:from-night-sky dark:to-indigo-950 dark:text-parchment">
+            <div className="mx-auto max-w-5xl px-4 py-4 flex items-center justify-between">
+              <Link href="/" className="text-2xl font-heading text-royal-gold">Elnsburg Continuum</Link>
+              <nav className="flex gap-6 text-sm text-night-sky dark:text-parchment">
+                <Link href="/novels" className="hover:text-royal-gold">Novels</Link>
+                <Link href="/wiki" className="hover:text-royal-gold">Wiki</Link>
+                <a href="/api/rss" className="hover:text-royal-gold">RSS</a>
+                <ThemeToggle />
+              </nav>
+            </div>
+          </header>
+          <main className="mx-auto max-w-5xl px-4 py-8">{children}</main>
+          <footer className="border-t border-royal-gold/20 mt-16 bg-gray-100 text-night-sky dark:bg-night-sky/50 dark:text-parchment">
+            <div className="mx-auto max-w-5xl px-4 py-8 text-sm text-center">
+              © {new Date().getFullYear()} The Elnsburg Continuum
+            </div>
+          </footer>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/novels/[series]/[chapter]/page.tsx
+++ b/app/novels/[series]/[chapter]/page.tsx
@@ -2,6 +2,7 @@ import { allChapters } from "contentlayer/generated";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { MDXContent } from "@/components/mdx-content";
+import { ReaderSettings } from "@/components/reader-settings";
 
 export function generateStaticParams() {
   return allChapters.map((c) => ({
@@ -25,8 +26,9 @@ export default function ChapterPage({ params }: { params: { series: string; chap
   const next = idx < seriesChapters.length - 1 ? seriesChapters[idx + 1] : null;
 
   return (
-    <article className="prose prose-invert prose-headings:font-heading prose-headings:text-royal-gold mx-auto">
+    <article className="prose dark:prose-invert prose-headings:font-heading prose-headings:text-royal-gold mx-auto reader-content">
       <h1>{doc.title}</h1>
+      <ReaderSettings />
       <MDXContent code={doc.body.code} />
       <hr />
       <nav className="flex justify-between text-sm">

--- a/components/reader-settings.tsx
+++ b/components/reader-settings.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function ReaderSettings() {
+  const [fontSize, setFontSize] = useState<number>(16);
+  const [lineHeight, setLineHeight] = useState<number>(1.75);
+
+  useEffect(() => {
+    const storedSize = Number(window.localStorage.getItem('reader-font-size'));
+    const storedLine = Number(window.localStorage.getItem('reader-line-height'));
+    if (!isNaN(storedSize)) setFontSize(storedSize);
+    if (!isNaN(storedLine)) setLineHeight(storedLine);
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--reader-font-size', `${fontSize}px`);
+    window.localStorage.setItem('reader-font-size', String(fontSize));
+  }, [fontSize]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--reader-line-height', `${lineHeight}`);
+    window.localStorage.setItem('reader-line-height', String(lineHeight));
+  }, [lineHeight]);
+
+  return (
+    <div className="mb-4 space-y-2 text-sm">
+      <div className="flex items-center gap-2">
+        <label htmlFor="font-size" className="w-24">Font Size</label>
+        <input
+          id="font-size"
+          type="range"
+          min={14}
+          max={24}
+          value={fontSize}
+          onChange={(e) => setFontSize(Number(e.target.value))}
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <label htmlFor="line-height" className="w-24">Line Height</label>
+        <input
+          id="line-height"
+          type="range"
+          min={1.2}
+          max={2}
+          step={0.05}
+          value={lineHeight}
+          onChange={(e) => setLineHeight(Number(e.target.value))}
+        />
+      </div>
+    </div>
+  );
+}
+

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+type ThemeContextValue = {
+  theme: Theme;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'dark',
+  toggleTheme: () => {}
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('dark');
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored);
+      document.documentElement.classList.add(stored);
+    } else {
+      document.documentElement.classList.add('dark');
+      window.localStorage.setItem('theme', 'dark');
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.remove(theme === 'dark' ? 'light' : 'dark');
+    document.documentElement.classList.add(theme);
+    window.localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 text-sm text-royal-gold border border-royal-gold rounded"
+      aria-label="Toggle theme"
+    >
+      {theme === 'dark' ? 'Light' : 'Dark'} Mode
+    </button>
+  );
+}
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: "class",
   content: [
     "./app/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",


### PR DESCRIPTION
## Summary
- add ThemeProvider with persistent dark/light mode and header toggle
- add ReaderSettings sliders for font size and line height
- support theme and reader styles with Tailwind dark mode and CSS variables

## Testing
- `npm run lint` *(fails: presented interactive configuration prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bb5f46f04832a98fb1abac2944d43