### PR TITLE
feat: add user accounts with progress and bookmarks

### DIFF
--- a/app/bookmarks/page.tsx
+++ b/app/bookmarks/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useAuth } from '@/components/auth-context';
+import Link from 'next/link';
+import { allChapters } from 'contentlayer/generated';
+
+export default function BookmarksPage() {
+  const { user } = useAuth();
+  if (!user) return <p>Please log in to view bookmarks.</p>;
+  const chapters = allChapters.filter(c => user.bookmarks[c._id]);
+  return (
+    <div className="space-y-6">
+      <h1 className="text-4xl font-heading text-royal-gold">Bookmarks</h1>
+      <ul className="space-y-3">
+        {chapters.map(c => (
+          <li key={c._id} className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded">
+            <Link href={c.slug} className="font-heading text-royal-gold">
+              {c.series}: Chapter {c.chapter} - {c.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      {!chapters.length && <p>No bookmarks yet.</p>}
+    </div>
+  );
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import "./globals.css";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Cinzel, Merriweather } from "next/font/google";
+import { AuthProvider } from "@/components/auth-context";
+import AuthStatus from "@/components/auth-status";
 
 export const metadata: Metadata = {
   title: "The Elnsburg Continuum",
@@ -23,22 +25,25 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={`${heading.variable} ${body.variable}`}>
       <body className="min-h-screen bg-gradient-to-br from-night-sky via-indigo-950 to-black text-parchment font-body">
-        <header className="border-b border-royal-gold/20 bg-gradient-to-r from-night-sky to-indigo-950 shadow-md">
-          <div className="mx-auto max-w-5xl px-4 py-4 flex items-center justify-between">
-            <Link href="/" className="text-2xl font-heading text-royal-gold">Elnsburg Continuum</Link>
-            <nav className="flex gap-6 text-sm text-parchment">
-              <Link href="/novels" className="hover:text-royal-gold">Novels</Link>
-              <Link href="/wiki" className="hover:text-royal-gold">Wiki</Link>
-              <a href="/api/rss" className="hover:text-royal-gold">RSS</a>
-            </nav>
-          </div>
-        </header>
-        <main className="mx-auto max-w-5xl px-4 py-8">{children}</main>
-        <footer className="border-t border-royal-gold/20 mt-16 bg-night-sky/50">
-          <div className="mx-auto max-w-5xl px-4 py-8 text-sm text-center text-parchment">
-            © {new Date().getFullYear()} The Elnsburg Continuum
-          </div>
-        </footer>
+        <AuthProvider>
+          <header className="border-b border-royal-gold/20 bg-gradient-to-r from-night-sky to-indigo-950 shadow-md">
+            <div className="mx-auto max-w-5xl px-4 py-4 flex items-center justify-between">
+              <Link href="/" className="text-2xl font-heading text-royal-gold">Elnsburg Continuum</Link>
+              <nav className="flex gap-6 text-sm text-parchment">
+                <Link href="/novels" className="hover:text-royal-gold">Novels</Link>
+                <Link href="/wiki" className="hover:text-royal-gold">Wiki</Link>
+                <a href="/api/rss" className="hover:text-royal-gold">RSS</a>
+                <AuthStatus />
+              </nav>
+            </div>
+          </header>
+          <main className="mx-auto max-w-5xl px-4 py-8">{children}</main>
+          <footer className="border-t border-royal-gold/20 mt-16 bg-night-sky/50">
+            <div className="mx-auto max-w-5xl px-4 py-8 text-sm text-center text-parchment">
+              © {new Date().getFullYear()} The Elnsburg Continuum
+            </div>
+          </footer>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/components/auth-context';
+
+export default function LoginPage() {
+  const [name, setName] = useState('');
+  const { login } = useAuth();
+  const router = useRouter();
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name) return;
+    login(name);
+    router.push('/');
+  };
+
+  return (
+    <form onSubmit={submit} className="max-w-sm mx-auto space-y-4">
+      <h1 className="text-2xl font-heading text-royal-gold">Login</h1>
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="w-full p-2 rounded bg-night-sky/40 border border-royal-gold/30"
+        placeholder="Username"
+      />
+      <button type="submit" className="px-4 py-2 bg-royal-gold text-night-sky rounded">
+        Login
+      </button>
+    </form>
+  );
+}
+

--- a/app/novels/[series]/[chapter]/page.tsx
+++ b/app/novels/[series]/[chapter]/page.tsx
@@ -2,6 +2,7 @@ import { allChapters } from "contentlayer/generated";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { MDXContent } from "@/components/mdx-content";
+import { ChapterActions } from "@/components/chapter-actions";
 
 export function generateStaticParams() {
   return allChapters.map((c) => ({
@@ -27,6 +28,7 @@ export default function ChapterPage({ params }: { params: { series: string; chap
   return (
     <article className="prose prose-invert prose-headings:font-heading prose-headings:text-royal-gold mx-auto">
       <h1>{doc.title}</h1>
+      <ChapterActions id={doc._id} />
       <MDXContent code={doc.body.code} />
       <hr />
       <nav className="flex justify-between text-sm">

--- a/app/novels/[series]/page.tsx
+++ b/app/novels/[series]/page.tsx
@@ -1,5 +1,5 @@
 import { allChapters } from 'contentlayer/generated';
-import Link from 'next/link';
+import ChapterListItem from '@/components/chapter-list-item';
 import { notFound } from 'next/navigation';
 
 export function generateStaticParams() {
@@ -17,10 +17,7 @@ export default function SeriesPage({ params }: { params: { series: string } }) {
       <h1 className="text-4xl font-heading text-royal-gold">{chapters[0].series}</h1>
       <ul className="space-y-3">
         {chapters.map(c => (
-          <li key={c._id} className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded">
-            <Link href={c.slug} className="font-heading text-royal-gold">Chapter {c.chapter}: {c.title}</Link>
-            {c.synopsis && <p className="text-sm mt-2 text-parchment/80">{c.synopsis}</p>}
-          </li>
+          <ChapterListItem key={c._id} chapter={c} />
         ))}
       </ul>
     </div>

--- a/components/auth-context.tsx
+++ b/components/auth-context.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type UserData = {
+  username: string;
+  read: Record<string, boolean>;
+  bookmarks: Record<string, boolean>;
+};
+
+type AuthContextValue = {
+  user: UserData | null;
+  login: (name: string) => void;
+  logout: () => void;
+  toggleRead: (id: string) => void;
+  toggleBookmark: (id: string) => void;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+function loadUser(name: string): UserData {
+  const raw = typeof window !== 'undefined' ? localStorage.getItem(`ec-user-${name}`) : null;
+  if (raw) return JSON.parse(raw) as UserData;
+  return { username: name, read: {}, bookmarks: {} };
+}
+
+function saveUser(user: UserData) {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(`ec-user-${user.username}`, JSON.stringify(user));
+  }
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<UserData | null>(null);
+
+  useEffect(() => {
+    const current = typeof window !== 'undefined' ? localStorage.getItem('ec-current-user') : null;
+    if (current) setUser(loadUser(current));
+  }, []);
+
+  const login = (name: string) => {
+    const u = loadUser(name);
+    setUser(u);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('ec-current-user', name);
+    }
+  };
+
+  const logout = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('ec-current-user');
+    }
+    setUser(null);
+  };
+
+  const toggleRead = (id: string) => {
+    if (!user) return;
+    const next = { ...user, read: { ...user.read, [id]: !user.read[id] } };
+    setUser(next);
+    saveUser(next);
+  };
+
+  const toggleBookmark = (id: string) => {
+    if (!user) return;
+    const next = { ...user, bookmarks: { ...user.bookmarks, [id]: !user.bookmarks[id] } };
+    setUser(next);
+    saveUser(next);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout, toggleRead, toggleBookmark }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}
+

--- a/components/auth-status.tsx
+++ b/components/auth-status.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import Link from 'next/link';
+import { useAuth } from './auth-context';
+
+export default function AuthStatus() {
+  const { user, logout } = useAuth();
+  if (user) {
+    return (
+      <>
+        <Link href="/bookmarks" className="hover:text-royal-gold">Bookmarks</Link>
+        <button onClick={logout} className="hover:text-royal-gold">Logout {user.username}</button>
+      </>
+    );
+  }
+  return <Link href="/login" className="hover:text-royal-gold">Login</Link>;
+}
+

--- a/components/chapter-actions.tsx
+++ b/components/chapter-actions.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useAuth } from './auth-context';
+
+export function ChapterActions({ id }: { id: string }) {
+  const { user, toggleBookmark, toggleRead } = useAuth();
+  if (!user) {
+    return <p className="text-sm mb-4">Log in to track your progress.</p>;
+  }
+  const read = !!user.read[id];
+  const bookmarked = !!user.bookmarks[id];
+  return (
+    <div className="flex gap-4 mb-4 text-sm">
+      <button onClick={() => toggleRead(id)}>{read ? 'Mark Unread' : 'Mark Read'}</button>
+      <button onClick={() => toggleBookmark(id)}>{bookmarked ? 'Remove Bookmark' : 'Bookmark'}</button>
+    </div>
+  );
+}
+

--- a/components/chapter-list-item.tsx
+++ b/components/chapter-list-item.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import Link from 'next/link';
+import { useAuth } from './auth-context';
+
+export default function ChapterListItem({ chapter }: { chapter: any }) {
+  const { user, toggleBookmark, toggleRead } = useAuth();
+  const read = user?.read[chapter._id];
+  const bookmarked = user?.bookmarks[chapter._id];
+  return (
+    <li className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded">
+      <div className="flex justify-between items-start">
+        <Link href={chapter.slug} className="font-heading text-royal-gold">
+          Chapter {chapter.chapter}: {chapter.title}
+        </Link>
+        {user && (
+          <div className="flex gap-2 text-sm">
+            <button onClick={() => toggleRead(chapter._id)}>{read ? '✓' : '○'}</button>
+            <button onClick={() => toggleBookmark(chapter._id)}>{bookmarked ? '★' : '☆'}</button>
+          </div>
+        )}
+      </div>
+      {chapter.synopsis && (
+        <p className="text-sm mt-2 text-parchment/80">{chapter.synopsis}</p>
+      )}
+    </li>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add local storage backed auth provider
- allow marking chapters read and bookmarking favorites
- show bookmarks page and login form

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (interactive prompt, requires manual configuration)

------
https://chatgpt.com/codex/tasks/task_e_689bbc2deaa4832aaf86f121e8c79a0b