### PR TITLE
Add basic authentication with reading progress and bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ An admin interface is available for quickly creating content without touching th
 - `(/admin)` for novel chapters
 - `(/admin/wiki)` for wiki entries
 
+## Authentication
+
+Sign in at `/login` using the demo credentials:
+
+- **username**: `demo`
+- **password**: `demo`
+
+Once authenticated, readers can mark chapters as read and bookmark their favourites.
+
 ## Authoring
 
 Use double brackets to link to wiki pages. Writing `[[elnsburg-overview]]` in your

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,5 @@
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };

--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { markRead, toggleBookmark } from "@/lib/userData";
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.name) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { slug, type } = await req.json();
+  if (type === "read") {
+    markRead(session.user.name, slug);
+  } else if (type === "bookmark") {
+    toggleBookmark(session.user.name, slug);
+  }
+  return NextResponse.json({ success: true });
+}

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getUser } from "@/lib/userData";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.name) {
+    return NextResponse.json({ progress: [], bookmarks: [] });
+  }
+  const user = getUser(session.user.name);
+  return NextResponse.json({
+    progress: user?.progress || [],
+    bookmarks: user?.bookmarks || [],
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import "./globals.css";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Cinzel, Merriweather } from "next/font/google";
+import AuthProvider from "@/components/auth-provider";
+import NavAuth from "@/components/nav-auth";
 
 export const metadata: Metadata = {
   title: "The Elnsburg Continuum",
@@ -23,22 +25,25 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={`${heading.variable} ${body.variable}`}>
       <body className="min-h-screen bg-gradient-to-br from-night-sky via-indigo-950 to-black text-parchment font-body">
-        <header className="border-b border-royal-gold/20 bg-gradient-to-r from-night-sky to-indigo-950 shadow-md">
-          <div className="mx-auto max-w-5xl px-4 py-4 flex items-center justify-between">
-            <Link href="/" className="text-2xl font-heading text-royal-gold">Elnsburg Continuum</Link>
-            <nav className="flex gap-6 text-sm text-parchment">
-              <Link href="/novels" className="hover:text-royal-gold">Novels</Link>
-              <Link href="/wiki" className="hover:text-royal-gold">Wiki</Link>
-              <a href="/api/rss" className="hover:text-royal-gold">RSS</a>
-            </nav>
-          </div>
-        </header>
-        <main className="mx-auto max-w-5xl px-4 py-8">{children}</main>
-        <footer className="border-t border-royal-gold/20 mt-16 bg-night-sky/50">
-          <div className="mx-auto max-w-5xl px-4 py-8 text-sm text-center text-parchment">
-            © {new Date().getFullYear()} The Elnsburg Continuum
-          </div>
-        </footer>
+        <AuthProvider>
+          <header className="border-b border-royal-gold/20 bg-gradient-to-r from-night-sky to-indigo-950 shadow-md">
+            <div className="mx-auto max-w-5xl px-4 py-4 flex items-center justify-between">
+              <Link href="/" className="text-2xl font-heading text-royal-gold">Elnsburg Continuum</Link>
+              <nav className="flex gap-6 text-sm text-parchment items-center">
+                <Link href="/novels" className="hover:text-royal-gold">Novels</Link>
+                <Link href="/wiki" className="hover:text-royal-gold">Wiki</Link>
+                <a href="/api/rss" className="hover:text-royal-gold">RSS</a>
+                <NavAuth />
+              </nav>
+            </div>
+          </header>
+          <main className="mx-auto max-w-5xl px-4 py-8">{children}</main>
+          <footer className="border-t border-royal-gold/20 mt-16 bg-night-sky/50">
+            <div className="mx-auto max-w-5xl px-4 py-8 text-sm text-center text-parchment">
+              © {new Date().getFullYear()} The Elnsburg Continuum
+            </div>
+          </footer>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import { useState } from "react";
+
+export default function LoginPage() {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await signIn("credentials", { username, password, callbackUrl: "/" });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-sm mx-auto space-y-4">
+      <h1 className="text-2xl font-heading text-royal-gold">Sign In</h1>
+      <input
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        className="w-full p-2 text-black"
+        placeholder="Username"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="w-full p-2 text-black"
+        placeholder="Password"
+      />
+      <button type="submit" className="bg-royal-gold text-night-sky px-4 py-2">
+        Sign In
+      </button>
+    </form>
+  );
+}

--- a/app/novels/[series]/[chapter]/page.tsx
+++ b/app/novels/[series]/[chapter]/page.tsx
@@ -2,6 +2,7 @@ import { allChapters } from "contentlayer/generated";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { MDXContent } from "@/components/mdx-content";
+import ChapterActions from "@/components/chapter-actions";
 
 export function generateStaticParams() {
   return allChapters.map((c) => ({
@@ -29,7 +30,8 @@ export default function ChapterPage({ params }: { params: { series: string; chap
       <h1>{doc.title}</h1>
       <MDXContent code={doc.body.code} />
       <hr />
-      <nav className="flex justify-between text-sm">
+      <ChapterActions slug={doc.slug} />
+      <nav className="flex justify-between text-sm mt-4">
         <div>{prev && <Link href={prev.slug}>← {prev.title}</Link>}</div>
         <div>{next && <Link href={next.slug}>{next.title} →</Link>}</div>
       </nav>

--- a/app/novels/[series]/page.tsx
+++ b/app/novels/[series]/page.tsx
@@ -1,6 +1,6 @@
 import { allChapters } from 'contentlayer/generated';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import ChapterList from '@/components/chapter-list';
 
 export function generateStaticParams() {
   const slugs = Array.from(new Set(allChapters.map(c => c.seriesSlug)));
@@ -15,14 +15,12 @@ export default function SeriesPage({ params }: { params: { series: string } }) {
   return (
     <div className="space-y-6">
       <h1 className="text-4xl font-heading text-royal-gold">{chapters[0].series}</h1>
-      <ul className="space-y-3">
-        {chapters.map(c => (
-          <li key={c._id} className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded">
-            <Link href={c.slug} className="font-heading text-royal-gold">Chapter {c.chapter}: {c.title}</Link>
-            {c.synopsis && <p className="text-sm mt-2 text-parchment/80">{c.synopsis}</p>}
-          </li>
-        ))}
-      </ul>
+      <ChapterList chapters={chapters.map(c => ({
+        _id: c._id,
+        slug: c.slug,
+        title: `Chapter ${c.chapter}: ${c.title}`,
+        synopsis: c.synopsis,
+      }))} />
     </div>
   );
 }

--- a/components/auth-provider.tsx
+++ b/components/auth-provider.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/components/chapter-actions.tsx
+++ b/components/chapter-actions.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession, signIn } from "next-auth/react";
+
+interface Props { slug: string; }
+
+export default function ChapterActions({ slug }: Props) {
+  const { data: session } = useSession();
+  const [read, setRead] = useState(false);
+  const [bookmarked, setBookmarked] = useState(false);
+
+  useEffect(() => {
+    if (session) {
+      fetch("/api/user")
+        .then((res) => res.json())
+        .then((d) => {
+          setRead(d.progress.includes(slug));
+          setBookmarked(d.bookmarks.includes(slug));
+        });
+    }
+  }, [session, slug]);
+
+  const markRead = async () => {
+    await fetch("/api/progress", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slug, type: "read" }),
+    });
+    setRead(true);
+  };
+
+  const toggleBookmark = async () => {
+    await fetch("/api/progress", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slug, type: "bookmark" }),
+    });
+    setBookmarked((b) => !b);
+  };
+
+  if (!session)
+    return (
+      <button onClick={() => signIn()} className="text-sm text-royal-gold">
+        Sign in to track progress
+      </button>
+    );
+
+  return (
+    <div className="flex gap-4 text-sm mt-4">
+      <button onClick={markRead} disabled={read} className="underline">
+        {read ? "Read" : "Mark as read"}
+      </button>
+      <button onClick={toggleBookmark} className="underline">
+        {bookmarked ? "Unbookmark" : "Bookmark"}
+      </button>
+    </div>
+  );
+}

--- a/components/chapter-list.tsx
+++ b/components/chapter-list.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+
+interface Chapter {
+  _id: string;
+  slug: string;
+  title: string;
+  synopsis?: string;
+}
+
+export default function ChapterList({ chapters }: { chapters: Chapter[] }) {
+  const { data: session } = useSession();
+  const [user, setUser] = useState<{ progress: string[]; bookmarks: string[] }>({
+    progress: [],
+    bookmarks: [],
+  });
+
+  useEffect(() => {
+    if (session) {
+      fetch("/api/user")
+        .then((res) => res.json())
+        .then((d) => setUser(d));
+    }
+  }, [session]);
+
+  return (
+    <ul className="space-y-3">
+      {chapters.map((c) => {
+        const read = user.progress.includes(c.slug);
+        const bookmarked = user.bookmarks.includes(c.slug);
+        return (
+          <li
+            key={c._id}
+            className="border border-royal-gold/30 bg-night-sky/40 backdrop-blur-sm p-4 rounded"
+          >
+            <Link href={c.slug} className="font-heading text-royal-gold">
+              {c.title}
+            </Link>
+            {read && <span className="ml-2">✓</span>}
+            {bookmarked && <span className="ml-1">★</span>}
+            {c.synopsis && (
+              <p className="text-sm mt-2 text-parchment/80">{c.synopsis}</p>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/components/nav-auth.tsx
+++ b/components/nav-auth.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useSession, signOut } from "next-auth/react";
+import Link from "next/link";
+
+export default function NavAuth() {
+  const { data: session } = useSession();
+  return session ? (
+    <button onClick={() => signOut()} className="hover:text-royal-gold">Sign out</button>
+  ) : (
+    <Link href="/login" className="hover:text-royal-gold">Sign in</Link>
+  );
+}

--- a/data/users.json
+++ b/data/users.json
@@ -1,0 +1,8 @@
+[
+  {
+    "username": "demo",
+    "password": "demo",
+    "progress": [],
+    "bookmarks": []
+  }
+]

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,24 @@
+import CredentialsProvider from "next-auth/providers/credentials";
+import type { NextAuthOptions } from "next-auth";
+import { getUser } from "@/lib/userData";
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        username: { label: "Username", type: "text" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        if (!credentials?.username || !credentials?.password) return null;
+        const user = getUser(credentials.username);
+        if (user && user.password === credentials.password) {
+          return { id: user.username, name: user.username };
+        }
+        return null;
+      },
+    }),
+  ],
+  session: { strategy: "jwt" },
+};

--- a/lib/userData.ts
+++ b/lib/userData.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface UserRecord {
+  username: string;
+  password: string;
+  progress: string[];
+  bookmarks: string[];
+}
+
+const filePath = path.join(process.cwd(), 'data', 'users.json');
+
+function readUsers(): UserRecord[] {
+  if (!fs.existsSync(filePath)) return [];
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  return JSON.parse(raw) as UserRecord[];
+}
+
+function writeUsers(users: UserRecord[]) {
+  fs.writeFileSync(filePath, JSON.stringify(users, null, 2));
+}
+
+export function getUser(username: string): UserRecord | undefined {
+  return readUsers().find(u => u.username === username);
+}
+
+export function markRead(username: string, slug: string) {
+  const users = readUsers();
+  const user = users.find(u => u.username === username);
+  if (!user) return;
+  if (!user.progress.includes(slug)) {
+    user.progress.push(slug);
+    writeUsers(users);
+  }
+}
+
+export function toggleBookmark(username: string, slug: string) {
+  const users = readUsers();
+  const user = users.find(u => u.username === username);
+  if (!user) return;
+  if (user.bookmarks.includes(slug)) {
+    user.bookmarks = user.bookmarks.filter(s => s !== slug);
+  } else {
+    user.bookmarks.push(slug);
+  }
+  writeUsers(users);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@contentlayer2/source-files": "^0.4.3",
         "clsx": "2.1.1",
         "next": "14.2.5",
+        "next-auth": "^4.24.11",
         "next-contentlayer2": "^0.4.3",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -1590,6 +1591,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2366,6 +2376,15 @@
       },
       "engines": {
         "node": ">=14.18"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/core-util-is": {
@@ -3264,6 +3283,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -4648,6 +4676,47 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "license": "ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.7.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@auth/core": "0.34.2",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-auth/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/next-contentlayer2": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-contentlayer2/-/next-contentlayer2-0.4.6.tgz",
@@ -4728,6 +4797,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4748,6 +4823,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.1.tgz",
+      "integrity": "sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/oo-ascii-tree": {
       "version": "1.113.0",
       "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.113.0.tgz",
@@ -4755,6 +4839,42 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.17.0"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -4996,6 +5116,34 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.27.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.0.tgz",
+      "integrity": "sha512-/DTYoB6mwwgPytiqQTh/7SFRL98ZdiD8Sk8zIUVOxtwq4oWcwrcd1uno9fE/zZmUaUrFNYzbH14CPebOz9tZQw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
       "license": "MIT"
     },
     "node_modules/property-information": {
@@ -6317,6 +6465,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,15 @@
   "dependencies": {
     "@contentlayer2/core": "^0.4.3",
     "@contentlayer2/source-files": "^0.4.3",
+    "clsx": "2.1.1",
     "next": "14.2.5",
+    "next-auth": "^4.24.11",
     "next-contentlayer2": "^0.4.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "remark-gfm": "4.0.0",
-    "rehype-slug": "6.0.0",
     "rehype-autolink-headings": "7.1.0",
-    "clsx": "2.1.1"
+    "rehype-slug": "6.0.0",
+    "remark-gfm": "4.0.0"
   },
   "devDependencies": {
     "@contentlayer2/cli": "^0.4.3",


### PR DESCRIPTION
## Summary
- integrate NextAuth credentials login and session provider
- allow users to mark chapters as read and bookmark chapters
- persist user progress in a simple JSON file

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: required interactive setup)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bbc2deaa4832aaf86f121e8c79a0b